### PR TITLE
Fix issue with Ruby 3.2 compatability

### DIFF
--- a/lib/active_shipping/package.rb
+++ b/lib/active_shipping/package.rb
@@ -143,7 +143,7 @@ module ActiveShipping #:nodoc:
 
     def measure(measurement, ary)
       case measurement
-      when Fixnum then ary[measurement]
+      when Integer then ary[measurement]
       when :x, :max, :length, :long then ary[2]
       when :y, :mid, :width, :wide then ary[1]
       when :z, :min, :height, :depth, :high, :deep then ary[0]

--- a/test/remote/fedex_test.rb
+++ b/test/remote/fedex_test.rb
@@ -33,7 +33,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -75,7 +75,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -134,7 +134,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -149,7 +149,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -164,7 +164,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -179,7 +179,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 
@@ -194,7 +194,7 @@ class RemoteFedExTest < Minitest::Test
     assert response.rates.length > 0
     response.rates.each do |rate|
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.price
+      assert_kind_of Integer, rate.price
     end
   end
 

--- a/test/remote/stamps_test.rb
+++ b/test/remote/stamps_test.rb
@@ -138,7 +138,7 @@ class RemoteStampsTest < Minitest::Test
     assert_equal '10017', response.rate.destination.zip
     assert_equal 'US', response.rate.destination.country_code
 
-    assert_instance_of Fixnum, response.rate.total_price
+    assert_kind_of Integer, response.rate.total_price
     assert_instance_of String, response.stamps_tx_id
 
     assert_nil response.label_url
@@ -169,7 +169,7 @@ class RemoteStampsTest < Minitest::Test
     assert_equal 'K1P 1J1', response.rate.destination.zip
     assert_equal 'CA', response.rate.destination.country_code
 
-    assert_instance_of Fixnum, response.rate.total_price
+    assert_kind_of Integer, response.rate.total_price
     assert_instance_of String, response.stamps_tx_id
     assert_instance_of String, response.label_url
 
@@ -299,8 +299,8 @@ class RemoteStampsTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'Stamps', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -328,8 +328,8 @@ class RemoteStampsTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'Stamps', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Interger, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/remote/ups_test.rb
+++ b/test/remote/ups_test.rb
@@ -79,12 +79,12 @@ class RemoteUPSTest < Minitest::Test
     assert_equal 'UPS', rate.carrier
     assert_equal 'CAD', rate.currency
     if @options[:origin_account]
-      assert_instance_of Fixnum, rate.negotiated_rate
+      assert_kind_of Integer, rate.negotiated_rate
     else
       assert_equal rate.negotiated_rate, 0
     end
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/remote/usps_test.rb
+++ b/test/remote/usps_test.rb
@@ -76,8 +76,8 @@ class RemoteUSPSTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'USPS', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -109,8 +109,8 @@ class RemoteUSPSTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'USPS', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates

--- a/test/unit/carriers/canada_post_test.rb
+++ b/test/unit/carriers/canada_post_test.rb
@@ -28,7 +28,7 @@ class CanadaPostTest < Minitest::Test
       assert_instance_of DateTime, rate.delivery_date
       assert_instance_of DateTime, rate.shipping_date
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.total_price
+      assert_kind_of Integer, rate.total_price
     end
 
     rate_estimates.boxes.each do |box|
@@ -41,7 +41,7 @@ class CanadaPostTest < Minitest::Test
       assert_instance_of Float, box.width
 
       box.packedItems.each do |p|
-        assert_instance_of Fixnum, p.quantity
+        assert_kind_of Integer, p.quantity
         assert_instance_of String, p.description
       end
     end
@@ -61,7 +61,7 @@ class CanadaPostTest < Minitest::Test
       assert_instance_of DateTime, rate.delivery_date
       assert_instance_of DateTime, rate.shipping_date
       assert_instance_of String, rate.service_name
-      assert_instance_of Fixnum, rate.total_price
+      assert_kind_of Integer, rate.total_price
     end
 
     rate_estimates.boxes.each do |box|
@@ -74,7 +74,7 @@ class CanadaPostTest < Minitest::Test
       assert_instance_of Float, box.width
 
       box.packedItems.each do |p|
-        assert_instance_of Fixnum, p.quantity
+        assert_kind_of Integer, p.quantity
         assert_instance_of String, p.description
       end
     end

--- a/test/unit/carriers/fedex_test.rb
+++ b/test/unit/carriers/fedex_test.rb
@@ -156,8 +156,8 @@ class FedExTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'FedEx', rate.carrier
     assert_equal 'USD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates
@@ -189,8 +189,8 @@ class FedExTest < Minitest::Test
     rate = response.rates.first
     assert_equal 'FedEx', rate.carrier
     assert_equal 'CAD', rate.currency
-    assert_instance_of Fixnum, rate.total_price
-    assert_instance_of Fixnum, rate.price
+    assert_kind_of Integer, rate.total_price
+    assert_kind_of Integer, rate.price
     assert_instance_of String, rate.service_name
     assert_instance_of String, rate.service_code
     assert_instance_of Array, rate.package_rates


### PR DESCRIPTION
This was done on the master branch already but since we have our own forked and branched version I copied it over.

https://github.com/pervino/active_shipping/commit/7e6090250425b9382059ecb5600f8712928214a2